### PR TITLE
fix(repository): 가계부 적은 내용 삭제시 무한 Select 실행되던 버그 수정

### DIFF
--- a/backend/src/interface/repository/cronGroupAccountBookRepository.ts
+++ b/backend/src/interface/repository/cronGroupAccountBookRepository.ts
@@ -66,6 +66,7 @@ export type TUpdateColumn = {
 export type TDeleteColumn = {
 	dependency: {
 		errorUtil: Pick<TErrorUtil, 'convertErrorToCustomError'>;
+		CronGroupAccountBookModel: typeof CronGroupAccountBookModel;
 	};
-	param: CronGroupAccountBookModel;
+	param: Partial<TColumnInfo>;
 };

--- a/backend/src/interface/repository/groupAccountBookRepository.ts
+++ b/backend/src/interface/repository/groupAccountBookRepository.ts
@@ -51,6 +51,7 @@ export type TUpdateColumn = {
 export type TDeleteColumn = {
 	dependency: {
 		errorUtil: Pick<TErrorUtil, 'convertErrorToCustomError'>;
+		GroupAccountBookModel: typeof GroupAccountBookModel;
 	};
-	param: GroupAccountBookModel;
+	param: Partial<TColumnInfo>;
 };

--- a/backend/src/repository/cronGroupAccountBookRepository/dependency.ts
+++ b/backend/src/repository/cronGroupAccountBookRepository/dependency.ts
@@ -37,4 +37,5 @@ export const updateColumn = Logic.updateColumn({
 
 export const deleteColumn = Logic.deleteColumn({
 	errorUtil: { convertErrorToCustomError },
+	CronGroupAccountBookModel,
 });

--- a/backend/src/repository/cronGroupAccountBookRepository/index.ts
+++ b/backend/src/repository/cronGroupAccountBookRepository/index.ts
@@ -173,10 +173,13 @@ export const deleteColumn =
 	async (column: TDeleteColumn['param']) => {
 		const {
 			errorUtil: { convertErrorToCustomError },
+			CronGroupAccountBookModel,
 		} = dependencies;
 
 		try {
-			await column.destroy();
+			const result = await CronGroupAccountBookModel.destroy({ where: column });
+
+			return result;
 		} catch (error) {
 			const customError = convertErrorToCustomError(error, {
 				trace: 'Repository',

--- a/backend/src/repository/groupAccountBookRepository/dependency.ts
+++ b/backend/src/repository/groupAccountBookRepository/dependency.ts
@@ -32,4 +32,5 @@ export const updateColumn = Logic.updateColumn({
 
 export const deleteColumn = Logic.deleteColumn({
 	errorUtil: { convertErrorToCustomError },
+	GroupAccountBookModel,
 });

--- a/backend/src/repository/groupAccountBookRepository/index.ts
+++ b/backend/src/repository/groupAccountBookRepository/index.ts
@@ -13,7 +13,7 @@ export const findGAB =
 	async (
 		gabInfo: TFindGAB['param'][0],
 		options?: TFindGAB['param'][1],
-	): Promise<InstanceType<typeof GroupAccountBookModel> | undefined> => {
+	): Promise<InstanceType<typeof GroupAccountBookModel> | null> => {
 		const {
 			GroupAccountBookModel,
 			GroupModel,
@@ -21,23 +21,21 @@ export const findGAB =
 		} = dependencies;
 
 		try {
-			const includeOption = options?.isIncludeGroup
-				? {
-						include: {
-							model: GroupModel,
-							as: 'groups',
-							required: true,
-						},
-				  }
-				: {};
-			const gab = await GroupAccountBookModel.findAll({
+			const includeList = [];
+			if (options?.isIncludeGroup) {
+				includeList.push({
+					model: GroupModel,
+					as: 'groups',
+					required: true,
+				});
+			}
+			const gab = await GroupAccountBookModel.findOne({
 				where: gabInfo,
-				...includeOption,
-				limit: 1,
+				include: includeList,
 				subQuery: false,
 			});
 
-			return gab[0];
+			return gab;
 		} catch (error) {
 			const customError = convertErrorToCustomError(error, {
 				trace: 'Repository',
@@ -134,10 +132,13 @@ export const deleteColumn =
 	async (column: TDeleteColumn['param']) => {
 		const {
 			errorUtil: { convertErrorToCustomError },
+			GroupAccountBookModel,
 		} = dependencies;
 
 		try {
-			await column.destroy();
+			const result = await GroupAccountBookModel.destroy({ where: column });
+
+			return result;
 		} catch (error) {
 			const customError = convertErrorToCustomError(error, {
 				trace: 'Repository',

--- a/backend/src/service/spendingIncomeService/index.ts
+++ b/backend/src/service/spendingIncomeService/index.ts
@@ -224,7 +224,7 @@ export const deleteFixedColumn =
 				});
 			}
 
-			await deleteFColumn(cgab);
+			await deleteFColumn({ id });
 
 			eventEmitter.emit('delete:fgab', {
 				accountBookId: cgab.groups.accountBookId,
@@ -264,7 +264,7 @@ export const deleteNotFixedColumn =
 				await checkAdminGroupUser({ userEmail, accountBookId: gab.groups.accountBookId });
 			}
 
-			await deleteNFColumn(gab);
+			await deleteNFColumn({ id });
 
 			eventEmitter.emit('delete:nfgab', {
 				accountBookId: gab.groups.accountBookId,

--- a/backend/src/test/service/spendingIncome.spec.ts
+++ b/backend/src/test/service/spendingIncome.spec.ts
@@ -1073,7 +1073,7 @@ describe('SpendingIncome Service Test', function () {
 				await injectedFunc({ id: 1, userEmail: requestUserInfo.userEmail });
 
 				sinon.assert.calledWith(stubFindFixedGAB, { id: 1 }, { isIncludeGroup: true });
-				sinon.assert.calledWith(stubDeleteFColumn, cgabJoinGroup);
+				sinon.assert.calledWith(stubDeleteFColumn, { id: 1 });
 				sinon.assert.calledWith(stubCheckAdminGroupUser, {
 					userEmail: requestUserInfo.userEmail,
 					accountBookId: cgabJoinGroup.groups.accountBookId,
@@ -1309,7 +1309,7 @@ describe('SpendingIncome Service Test', function () {
 				});
 
 				sinon.assert.calledWith(stubFindNotFixedGAB, { id: 1 }, { isIncludeGroup: true });
-				sinon.assert.calledWith(stubDeleteNFColumn, gabJoinGroup);
+				sinon.assert.calledWith(stubDeleteNFColumn, { id: 1 });
 				sinon.assert.calledWith(stubCheckAdminGroupUser, {
 					userEmail: requestUserInfo.userEmail,
 					accountBookId: gabJoinGroup.groups.accountBookId,


### PR DESCRIPTION
Join된 Sequelize Model 객체에서 destroy 함수 호출시 발생하는 것으로 파악됨